### PR TITLE
chore: release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -52,12 +52,16 @@ jobs:
           git fetch
           git checkout "$pr_branch_name"
 
-          # Update the version of lumina-node-wasm dependency
           node_wasm_version="$(cargo pkgid --manifest-path=node-wasm/Cargo.toml | cut -d@ -f 2)"
           cd node-wasm/js
-          npm pkg set "dependencies[lumina-node-wasm]=$node_wasm_version"
+
           # Update lumina-node version
-          npm version $node_wasm_version
+          if ! $(npm version $node_wasm_version); then
+            echo "Version up to date"
+            exit
+          fi
+          # Update the version of lumina-node-wasm dependency
+          npm pkg set "dependencies[lumina-node-wasm]=$node_wasm_version"
 
           # push a commit to release-plz's pr
           # prepare graphql query
@@ -90,7 +94,8 @@ jobs:
             --data "$(echo "$query" | tr -d '\n')")
 
           if $(echo "$result" | jq -e '.errors | length != 0'); then
-            echo "Commit failed: $(echo "$result" | jq '.errors')"
+            echo "Commit failed: $(echo "$result" | jq '.errors')" >&2
+            exit 1
           fi
 
       - name: Release to npm

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -56,7 +56,7 @@ jobs:
           cd node-wasm/js
 
           # Update lumina-node version
-          if ! $(npm version $node_wasm_version); then
+          if ! npm version $node_wasm_version >/dev/null; then
             echo "Version up to date"
             exit
           fi
@@ -93,9 +93,11 @@ jobs:
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             --data "$(echo "$query" | tr -d '\n')")
 
-          if $(echo "$result" | jq -e '.errors | length != 0'); then
+          if echo "$result" | jq -e '.errors | length != 0' >/dev/null; then
             echo "Commit failed: $(echo "$result" | jq '.errors')" >&2
             exit 1
+          else
+            echo "Version updated: ${node_wasm_version}"
           fi
 
       - name: Release to npm

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -66,7 +66,7 @@ jobs:
           query='{"query": "mutation {
             createCommitOnBranch(input: {
               branch: {
-                repositoryNameWithOwner: \"eigerco/lumina\",
+                repositoryNameWithOwner: \"zvolin/lumina\",
                 branchName: \"'"$pr_branch_name"'\"
               },
               message: {

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -44,26 +44,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
-          node_wasm_version="$(cargo pkgid --manifest-path=node-wasm/Cargo.toml | cut -d@ -f 2)"
+          set +x
+          pr_branch_name=${{ steps.release-plz.outputs.pr.head_branch }}
 
-          cd node-wasm/js
+          # switch to the branch created by release-plz
+          git fetch
+          git checkout "$pr_branch_name"
+
           # Update the version of lumina-node-wasm dependency
+          node_wasm_version="$(cargo pkgid --manifest-path=node-wasm/Cargo.toml | cut -d@ -f 2)"
+          cd node-wasm/js
           npm pkg set "dependencies[lumina-node-wasm]=$node_wasm_version"
           # Update lumina-node version
           npm version $node_wasm_version
 
           # push a commit to release-plz's pr
-          # fetch the branch created by release-plz
-          git fetch
           # prepare graphql query
-          branch_name=${{ steps.release-plz.outputs.pr.head_branch }}
-          branch_sha="$(git rev-parse "$branch_name")"
+          branch_sha="$(git rev-parse "$pr_branch_name")"
           package_json="$(base64 --wrap 0 package.json)"
           query='{"query": "mutation {
             createCommitOnBranch(input: {
               branch: {
                 repositoryNameWithOwner: \"eigerco/lumina\",
-                branchName: \"'"$branch_name"'\"
+                branchName: \"'"$pr_branch_name"'\"
               },
               message: {
                 headline: \"update lumina-node npm package\"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -44,7 +44,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
-          set -x
+          set -eu
+
           pr_branch_name="${{ fromJSON(steps.release-plz.outputs.pr).head_branch }}"
 
           # switch to the branch created by release-plz
@@ -82,11 +83,15 @@ jobs:
             { commit { commitUrl } }
           }"}'
           # create new commit with changes
-          curl https://api.github.com/graphql \
+          result=$(curl -sS https://api.github.com/graphql \
             -H "Accept: application/vnd.github+json" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            --data "$(echo "$query" | tr -d '\n')"
+            --data "$(echo "$query" | tr -d '\n')")
+
+          if $(echo "$result" | jq -e '.errors | length != 0'); then
+            echo "Commit failed: $(echo "$result" | jq '.errors')"
+          fi
 
       - name: Release to npm
         env:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -44,8 +44,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
-          set +x
-          pr_branch_name=${{ steps.release-plz.outputs.pr.head_branch }}
+          set -x
+          pr_branch_name="${{ fromJSON(steps.release-plz.outputs.pr).head_branch }}"
 
           # switch to the branch created by release-plz
           git fetch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "celestia-proto"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "celestia-tendermint-proto",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "bech32",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "lumina-node-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blockstore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ members = ["cli", "node", "node-wasm", "proto", "rpc", "types"]
 
 [workspace.dependencies]
 blockstore = "0.7.0"
-lumina-node = { version = "0.3.1", path = "node" }
-lumina-node-wasm = { version = "0.2.0", path = "node-wasm" }
-celestia-proto = { version = "0.3.0", path = "proto" }
-celestia-rpc = { version = "0.4.0", path = "rpc", default-features = false }
-celestia-types = { version = "0.4.0", path = "types", default-features = false }
+lumina-node = { version = "0.4.0", path = "node" }
+lumina-node-wasm = { version = "0.3.0", path = "node-wasm" }
+celestia-proto = { version = "0.3.1", path = "proto" }
+celestia-rpc = { version = "0.4.1", path = "rpc", default-features = false }
+celestia-types = { version = "0.5.0", path = "types", default-features = false }
 libp2p = "0.54.0"
 nmt-rs = "0.2.1"
 celestia-tendermint = { version = "0.32.2", default-features = false }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/zvolin/lumina/compare/lumina-cli-v0.3.0...lumina-cli-v0.3.1) - 2024-09-20
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.3.0](https://github.com/eigerco/lumina/compare/lumina-cli-v0.2.0...lumina-cli-v0.3.0) - 2024-08-13
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/node-wasm/CHANGELOG.md
+++ b/node-wasm/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/zvolin/lumina/compare/lumina-node-wasm-v0.2.0...lumina-node-wasm-v0.3.0) - 2024-09-20
+
+### Added
+
+- *(node-wasm)* [**breaking**] Align JS api to use camelCase ([#383](https://github.com/zvolin/lumina/pull/383))
+- *(node-wasm)* [**breaking**] Webpack compatibility ([#377](https://github.com/zvolin/lumina/pull/377))
+- *(node)* [**breaking**] Implement graceful shutdown ([#343](https://github.com/zvolin/lumina/pull/343))
+
+### Other
+
+- *(ci)* Automatic release to npmjs ([#378](https://github.com/zvolin/lumina/pull/378))
+
 ## [0.2.0](https://github.com/eigerco/lumina/compare/lumina-node-wasm-v0.1.1...lumina-node-wasm-v0.2.0) - 2024-08-13
 
 ### Added

--- a/node-wasm/Cargo.toml
+++ b/node-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node-wasm"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Browser compatibility layer for the Lumina node"

--- a/node-wasm/js/package.json
+++ b/node-wasm/js/package.json
@@ -5,7 +5,7 @@
         "Eiger <hello@eiger.co>"
     ],
     "description": "Lumina node for Celestia, running in browser",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
@@ -19,7 +19,7 @@
     "main": "index.js",
     "homepage": "https://www.eiger.co",
     "dependencies": {
-        "lumina-node-wasm": "0.2.0"
+        "lumina-node-wasm": "0.3.0"
     },
     "keywords": [
         "blockchain",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/zvolin/lumina/compare/lumina-node-v0.3.1...lumina-node-v0.4.0) - 2024-09-20
+
+### Added
+
+- *(node)* [**breaking**] Implement graceful shutdown ([#343](https://github.com/zvolin/lumina/pull/343))
+- *(node)* adding agent version ([#379](https://github.com/zvolin/lumina/pull/379))
+
+### Fixed
+
+- *(node)* [**breaking**] Remove unneded idb dependency ([#380](https://github.com/zvolin/lumina/pull/380))
+
+### Other
+
+- [**breaking**] Upgrade blockstore and beetswap ([#382](https://github.com/zvolin/lumina/pull/382))
+
 ## [0.3.1](https://github.com/eigerco/lumina/compare/lumina-node-v0.3.0...lumina-node-v0.3.1) - 2024-08-22
 
 ### Added

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lumina-node"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Celestia data availability node implementation in Rust"

--- a/proto/CHANGELOG.md
+++ b/proto/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/zvolin/lumina/compare/celestia-proto-v0.3.0...celestia-proto-v0.3.1) - 2024-09-20
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.3.0](https://github.com/eigerco/lumina/compare/celestia-proto-v0.2.0...celestia-proto-v0.3.0) - 2024-08-13
 
 ### Fixed

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-proto"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of proto structs used in celestia ecosystem"

--- a/rpc/CHANGELOG.md
+++ b/rpc/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/zvolin/lumina/compare/celestia-rpc-v0.4.0...celestia-rpc-v0.4.1) - 2024-09-20
+
+### Added
+
+- feat!(types,rpc): Add share, row, merkle proofs and share.GetRange ([#375](https://github.com/zvolin/lumina/pull/375))
+
 ## [0.4.0](https://github.com/eigerco/lumina/compare/celestia-rpc-v0.3.0...celestia-rpc-v0.4.0) - 2024-08-22
 
 ### Added

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-rpc"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A collection of traits for interacting with Celestia data availability nodes RPC"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/zvolin/lumina/compare/celestia-types-v0.4.0...celestia-types-v0.5.0) - 2024-09-20
+
+### Added
+
+- feat!(types,rpc): Add share, row, merkle proofs and share.GetRange ([#375](https://github.com/zvolin/lumina/pull/375))
+
 ## [0.4.0](https://github.com/eigerco/lumina/compare/celestia-types-v0.3.0...celestia-types-v0.4.0) - 2024-08-22
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celestia-types"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core types, traits and constants for working with the Celestia ecosystem"


### PR DESCRIPTION
## 🤖 New release
* `lumina-cli`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `celestia-rpc`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `celestia-types`: 0.4.0 -> 0.5.0 (⚠️ API breaking changes)
* `celestia-proto`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `lumina-node`: 0.3.1 -> 0.4.0 (⚠️ API breaking changes)
* `lumina-node-wasm`: 0.2.0 -> 0.3.0

### ⚠️ `celestia-types` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:IndexOutOfRange in /tmp/.tmpaxeRQv/lumina/types/src/error.rs:169
```

### ⚠️ `lumina-node` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant HeaderExError:RequestCancelled in /tmp/.tmpaxeRQv/lumina/node/src/p2p/header_ex.rs:96

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/trait_method_added.ron

Failed in:
  trait method lumina_node::store::Store::close in file /tmp/.tmpaxeRQv/lumina/node/src/store.rs:162
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lumina-cli`
<blockquote>

## [0.3.1](https://github.com/zvolin/lumina/compare/lumina-cli-v0.3.0...lumina-cli-v0.3.1) - 2024-09-20

### Other

- update Cargo.lock dependencies
</blockquote>

## `celestia-rpc`
<blockquote>

## [0.4.1](https://github.com/zvolin/lumina/compare/celestia-rpc-v0.4.0...celestia-rpc-v0.4.1) - 2024-09-20

### Added

- feat!(types,rpc): Add share, row, merkle proofs and share.GetRange ([#375](https://github.com/zvolin/lumina/pull/375))
</blockquote>

## `celestia-types`
<blockquote>

## [0.5.0](https://github.com/zvolin/lumina/compare/celestia-types-v0.4.0...celestia-types-v0.5.0) - 2024-09-20

### Added

- feat!(types,rpc): Add share, row, merkle proofs and share.GetRange ([#375](https://github.com/zvolin/lumina/pull/375))
</blockquote>

## `celestia-proto`
<blockquote>

## [0.3.1](https://github.com/zvolin/lumina/compare/celestia-proto-v0.3.0...celestia-proto-v0.3.1) - 2024-09-20

### Other

- update Cargo.toml dependencies
</blockquote>

## `lumina-node`
<blockquote>

## [0.4.0](https://github.com/zvolin/lumina/compare/lumina-node-v0.3.1...lumina-node-v0.4.0) - 2024-09-20

### Added

- *(node)* [**breaking**] Implement graceful shutdown ([#343](https://github.com/zvolin/lumina/pull/343))
- *(node)* adding agent version ([#379](https://github.com/zvolin/lumina/pull/379))

### Fixed

- *(node)* [**breaking**] Remove unneded idb dependency ([#380](https://github.com/zvolin/lumina/pull/380))

### Other

- [**breaking**] Upgrade blockstore and beetswap ([#382](https://github.com/zvolin/lumina/pull/382))
</blockquote>

## `lumina-node-wasm`
<blockquote>

## [0.3.0](https://github.com/zvolin/lumina/compare/lumina-node-wasm-v0.2.0...lumina-node-wasm-v0.3.0) - 2024-09-20

### Added

- *(node-wasm)* [**breaking**] Align JS api to use camelCase ([#383](https://github.com/zvolin/lumina/pull/383))
- *(node-wasm)* [**breaking**] Webpack compatibility ([#377](https://github.com/zvolin/lumina/pull/377))
- *(node)* [**breaking**] Implement graceful shutdown ([#343](https://github.com/zvolin/lumina/pull/343))

### Other

- *(ci)* Automatic release to npmjs ([#378](https://github.com/zvolin/lumina/pull/378))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).